### PR TITLE
Updated formatting in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ k8s-validate [--kubernetes-version X.X.X] [--exclude glob-pattern] files
 ```
 
 Add a section similar to this to your .pre-commit-hooks.yaml:
+
+```
+repos:
   - repo: https://github.com/Agilicus/pre-commit-hook-k8svalidate.git
     rev: v0.0.8
     hooks:
       - id: k8svalidate
         args: [--exclude, "**/*.patch.yaml"]
         files: .yaml$
+```


### PR DESCRIPTION
This PR fixes the formatting in the README.md so that the `hooks` section doesn't look squished:

![Screenshot 2020-07-21 15 03 42](https://user-images.githubusercontent.com/619921/88095617-67afd980-cb63-11ea-8ea5-93b071c2229d.png)
